### PR TITLE
changed display for `li > p`

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -169,7 +169,13 @@ blockquote /* for preview */
 /************************************/
 
 /* bullet lists */
-ul {list-style: none}
+ul { list-style: none; }
+li > p {
+  display: inline-block;
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
 ul li:not(.task-list-item)::before {
     content: "•";
     color: var(--blockquote-border);


### PR DESCRIPTION
As per fix on 80's neon theme: https://github.com/deathau/80s-Neon-for-Obsidian.md/issues/1

Noticed you'd copied this code, so thought you could use the fix 😉 